### PR TITLE
fix(docker/build-image): use last stable version of docker/metadata-action

### DIFF
--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -144,8 +144,7 @@ runs:
           core.setFailed(`No tags found for the current event: ${context.eventName}`);
 
     - id: docker-metadata
-      # FIXME: use stable version
-      uses: docker/metadata-action@master
+      uses: docker/metadata-action@v4.6.0
       with:
         images: ${{ steps.image-name.outputs.image-name-with-registry }}
         tags: ${{ steps.define-meta-tags.outputs.result }}


### PR DESCRIPTION
Fixes: https://github.com/hoverkraft-tech/ci-github-container/issues/59