### PR TITLE
feat: add buildx extra cache directives

### DIFF
--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -192,6 +192,7 @@ runs:
         flavor: ${{ steps.get-docker-config.outputs.cache-flavor }}
         pull-request-cache: true
         cache-type: gha
+        extra-cache-to: "image-manifest=true,oci-mediatypes=true"
 
     - if: steps.get-docker-config.outputs.docker-exists != 'true'
       uses: docker/setup-docker-action@v4


### PR DESCRIPTION
For storing cache image to harbor registry it seems that you have to add some extra cache parameters (with a dependency on buildx > 0.12)

see https://github.com/goharbor/harbor/pull/18105#issuecomment-1811951274