### PR TITLE
feat: add optional token and secret-envs

### DIFF
--- a/.github/workflows/docker-build-images.yml
+++ b/.github/workflows/docker-build-images.yml
@@ -76,6 +76,24 @@ on: # yamllint disable-line rule:truthy
           ]
         type: string
         required: true
+      app-id:
+        type: string
+        default: ""
+        description: |
+          Optional Github Application ID to generate token via actions/create-github-app-token.
+          Need that app-key secret defined to be used.
+          Minimal permissions needed are:
+          - contents:read
+          - issues:read
+        required: false
+      app-token-to-docker-secret-envs-keys:
+        type: string
+        default: ""
+        description: |
+          Used only if app-id input and app-key secret are set.
+          List of keys to set with the Github application token generated and set as docker secrets.
+          (string with keys separated by ',')
+        required: false
     secrets:
       oci-registry-password:
         description: |
@@ -86,6 +104,10 @@ on: # yamllint disable-line rule:truthy
         description: |
           List of secrets to expose to the build.
           See <https://docs.docker.com/build/ci/github-actions/secrets/>.
+        required: false
+      app-key:
+        description: |
+          Optional Github Application private key to generate token via actions/create-github-app-token.
         required: false
 
 permissions:
@@ -282,6 +304,14 @@ jobs:
       # FIXME: This is a workaround for having workflow actions. See https://github.com/orgs/community/discussions/38659
       id-token: write
     steps:
+      - name: Creates a Github Application token and inputs.app-id is set
+        id: app-token
+        if: inputs.app-id
+        uses: actions/create-github-app-token@v1.11.3
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-key }}
+          owner: ${{ github.repository_owner }}
       # FIXME: This is a workaround for having workflow actions. See https://github.com/orgs/community/discussions/38659
       - id: oidc
         uses: ChristopherHX/oidc@v3
@@ -290,9 +320,28 @@ jobs:
           path: ./self-workflow
           repository: ${{ steps.oidc.outputs.job_workflow_repo_name_and_owner }}
           ref: ${{ steps.oidc.outputs.job_workflow_repo_ref }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          persist-credentials: ${{ steps.app-token.outputs.token == '' }}
       - run: |
           echo "self-workflow" >> .gitignore
           echo "self-workflow" >> .dockerignore
+
+      - id: generate-app-token-to-docker-secret-envs-keys
+        name: Generate app token to docker secrets env keys
+        shell: bash
+        if: steps.app-token.outputs.token && inputs.app-token-to-docker-secret-envs-keys
+        env:
+          SECRETS_ENV_KEYS: ${{ inputs.app-token-to-docker-secret-envs-keys }}
+        run: |
+          SECRETS_ENV_KEYS=$(echo "$SECRETS_ENV_KEYS" | tr ',' '|')
+
+          echo 'secret-envs<<EOF' >> "$GITHUB_OUTPUT"
+          for key in $(echo "$SECRETS_ENV_KEYS" | tr ',' ' '); do
+            echo "\"${key}=APP_TOKEN\"" >> "$GITHUB_OUTPUT"
+          done
+          echo EOF >> "$GITHUB_OUTPUT"
+
+          echo "APP_TOKEN=${{ steps.app-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - id: build
         uses: ./self-workflow/actions/docker/build-image
@@ -309,6 +358,8 @@ jobs:
           target: ${{ matrix.image.target }}
           platform: ${{ matrix.image.platform }}
           secrets: ${{ secrets.build-secrets }}
+          secret-envs: ${{ steps.generate-app-token-to-docker-secret-envs-keys.outputs.secret-envs || '' }}
+          token: ${{ steps.app-token.outputs.token }}
 
       # FIXME: Set built images infos in file to be uploaded as artifacts, because github action does not handle job outputs for matrix
       # https://github.com/orgs/community/discussions/26639
@@ -371,6 +422,14 @@ jobs:
 
             core.setOutput('built-images', JSON.stringify(images));
 
+      - name: Creates a Github Application token if inputs.app-id is set
+        id: app-token
+        if: inputs.app-id
+        uses: actions/create-github-app-token@v1.11.3
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.app-key }}
+          owner: ${{ github.repository_owner }}
       # FIXME: This is a workaround for having workflow ref. See https://github.com/orgs/community/discussions/38659
       - id: oidc
         uses: ChristopherHX/oidc@v3
@@ -379,6 +438,8 @@ jobs:
           path: ./self-workflow
           repository: ${{ steps.oidc.outputs.job_workflow_repo_name_and_owner }}
           ref: ${{ steps.oidc.outputs.job_workflow_repo_ref }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          persist-credentials: ${{ steps.app-token.outputs.token == '' }}
       - name: ignore self-worfklow changes
         run: |
           echo "self-workflow" >> .gitignore

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -98,6 +98,15 @@ inputs:
       List of secrets to expose to the build.
       See <https://docs.docker.com/build/ci/github-actions/secrets/>.
     required: false
+  secret-envs:
+    description: |
+      List of secret-envs to expose to the build.
+      See <https://docs.docker.com/build/ci/github-actions/secrets/>.
+    required: false
+  token:
+    description: |
+      Token to use to interact with Github instead of the default GITHUB_TOKEN.
+    required: false
 
 runs:
   using: "composite"
@@ -115,6 +124,7 @@ runs:
         repository: ${{ inputs.repository }}
         image: ${{ inputs.image }}
         tag: ${{ inputs.tag }}
+        token: ${{ inputs.token }}
 
     - shell: bash
       # FIXME: workaround until will be merged: https://github.com/actions/runner/pull/1684
@@ -191,6 +201,7 @@ runs:
     - uses: hoverkraft-tech/ci-github-common/actions/checkout@0.17.0
       with:
         lfs: true
+        token: ${{ inputs.token }}
 
     - shell: bash
       run: git lfs pull
@@ -225,6 +236,7 @@ runs:
         target: ${{ inputs.target }}
         file: ${{ github.workspace }}/${{ inputs.context }}/${{ inputs.dockerfile }}
         secrets: ${{ inputs.secrets }}
+        secret-envs: ${{ inputs.secret-envs }}
         platforms: ${{ inputs.platform }}
         cache-from: ${{ steps.cache.outputs.cache-from }}
         cache-to: ${{ steps.cache.outputs.cache-to }}

--- a/actions/docker/get-image-metadata/action.yml
+++ b/actions/docker/get-image-metadata/action.yml
@@ -35,6 +35,9 @@ inputs:
   tag:
     description: "Force image tag to publish"
     required: false
+  token:
+    description: "Optional token to use for checking out the repository instead of the default GITHUB_TOKEN."
+    required: false
 
 runs:
   using: "composite"
@@ -63,6 +66,8 @@ runs:
       uses: hoverkraft-tech/ci-github-common/actions/get-issue-number@0.17.0
 
     - uses: hoverkraft-tech/ci-github-common/actions/checkout@0.17.0
+      with:
+        token: ${{ inputs.token }}
 
     - id: define-metadata-inputs
       uses: actions/github-script@v7.0.1
@@ -108,6 +113,7 @@ runs:
         tags: ${{ steps.define-metadata-inputs.outputs.tags }}
         flavor: ${{ steps.define-metadata-inputs.outputs.flavor }}
         context: git
+        github-token: ${{ inputs.token || github.token }}
       env:
         DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,manifest-descriptor
 


### PR DESCRIPTION
This pull request includes significant updates to the GitHub Actions workflows and related documentation to support the use of GitHub Application tokens. The most important changes include adding new inputs and secrets for GitHub Application tokens, updating workflow steps to handle these tokens, and modifying related action files to support the new functionality.

### Workflow Enhancements:

* [`.github/workflows/docker-build-images.md`](diffhunk://#diff-c5f28bd5dc1e2fc23df850e9ced6d77d54b09b297618a1f4915e6fd63814a439R82-R93): Added new inputs `app-id` and `app-token-to-docker-secret-envs-keys`, and a new secret `app-key` to support GitHub Application tokens. [[1]](diffhunk://#diff-c5f28bd5dc1e2fc23df850e9ced6d77d54b09b297618a1f4915e6fd63814a439R82-R93) [[2]](diffhunk://#diff-c5f28bd5dc1e2fc23df850e9ced6d77d54b09b297618a1f4915e6fd63814a439R104-R105) [[3]](diffhunk://#diff-c5f28bd5dc1e2fc23df850e9ced6d77d54b09b297618a1f4915e6fd63814a439R119-R120)
* [`.github/workflows/docker-build-images.yml`](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR79-R96): Updated the workflow to include steps for creating a GitHub Application token, generating secrets, and using these tokens in the build process. [[1]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR79-R96) [[2]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR108-R111) [[3]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR307-R314) [[4]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR323-R345) [[5]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR361-R362) [[6]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR425-R432) [[7]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR441-R442)

### Action File Updates:

* [`actions/docker/build-image/README.md`](diffhunk://#diff-d384d3b448dd1ffc97a4d317d15a12b3360d3f8731aece711f29b2d0fee5a8f3R102-R110): Added descriptions for new inputs `secret-envs` and `token` for exposing secrets and using custom tokens. [[1]](diffhunk://#diff-d384d3b448dd1ffc97a4d317d15a12b3360d3f8731aece711f29b2d0fee5a8f3R102-R110) [[2]](diffhunk://#diff-d384d3b448dd1ffc97a4d317d15a12b3360d3f8731aece711f29b2d0fee5a8f3R130-R131)
* [`actions/docker/build-image/action.yml`](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869R101-R109): Added new inputs `secret-envs` and `token`, and updated steps to use these inputs. [[1]](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869R101-R109) [[2]](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869R127) [[3]](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869L191-R204) [[4]](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869R239)

### Metadata Action Updates:

* [`actions/docker/get-image-metadata/README.md`](diffhunk://#diff-6b3003a113b8d0aa4f768e63f20ae0ccab2b72891de5e67bbd806eb95c8ce62bR48-R51): Added a new input `token` for using a custom token for repository checkout. [[1]](diffhunk://#diff-6b3003a113b8d0aa4f768e63f20ae0ccab2b72891de5e67bbd806eb95c8ce62bR48-R51) [[2]](diffhunk://#diff-6b3003a113b8d0aa4f768e63f20ae0ccab2b72891de5e67bbd806eb95c8ce62bR63)
* [`actions/docker/get-image-metadata/action.yml`](diffhunk://#diff-ea046ec82ea2211b4a71615614f13cd10afb67a9b38fa9c8558dc8a7b0e3b278R38-R40): Added a new input `token`, and updated steps to use this token. [[1]](diffhunk://#diff-ea046ec82ea2211b4a71615614f13cd10afb67a9b38fa9c8558dc8a7b0e3b278R38-R40) [[2]](diffhunk://#diff-ea046ec82ea2211b4a71615614f13cd10afb67a9b38fa9c8558dc8a7b0e3b278L65-R70) [[3]](diffhunk://#diff-ea046ec82ea2211b4a71615614f13cd10afb67a9b38fa9c8558dc8a7b0e3b278R116)

These changes enhance the security and flexibility of the workflows by allowing the use of GitHub Application tokens, which can provide more granular permissions and better security practices.

### How to use it

```
  build-ci:
    # FIXME: This is a workaround for having workflow actions. See https://github.com/orgs/community/discussions/38659
    permissions:
      id-token: write
      contents: read
      packages: write
      issues: read
      pull-requests: read
      actions: write
    uses: Groupe-Hevea/ci-github-container/.github/workflows/docker-build-images.yml@feat/add-github-application-token-option # hoverkraft-tech/ci-github-container/.github/workflows/docker-build-images.yml@5b53f22d16042c9ddf944be7323d47e2b977310d # 0.20.2
    needs: prepare-variables-ci
    with:
      oci-registry: ${{ vars.OCI_REGISTRY }}
      images: |
        [
          {
            "name": "ci",
            "context": ".",
            "dockerfile": "Dockerfile",
            "build-args": { "PROD_MODE": "" },
            "target": "ci",
            "platforms": ["linux/amd64"]
          }
        ]
      app-id: ${{ vars.APP_ID }}
      app-token-to-docker-secret-envs-keys: "GITHUB_TOKEN"
    secrets:
      oci-registry-password: ${{ secrets.OCI_REGISTRY_PASSWORD }}
      app-key: ${{ secrets.APP_KEY }}

```

It will generate an installation token based on your installed Github Application and map secret named `GITHUB_TOKEN` to env var `APP_TOKEN` with generated token via `actions/create-github-app-token`.

> [!NOTE]  
> We can NOT use application token instead of `oci-registry-password` for the moment, https://docs.github.com/en/packages/learn-github-packages/about-permissions-for-github-packages#about-scopes-and-permissions-for-package-registries
![{BBFC8EEE-1CD5-4357-BAB5-1564F8AA1FB6}](https://github.com/user-attachments/assets/d62839ff-0b1e-49b3-88c4-c8d0df9cd2f3)


> [!WARNING]  
> Depends on https://github.com/hoverkraft-tech/ci-github-common/pull/298 for `checkout ci-github-common/actions/checkout` a commit dedicated to switch to the new version is needed before merging this PR.