### PR TITLE
feat(docker-build-images)!: optimize GitHub checkout calls

### DIFF
--- a/.github/workflows/docker-build-images.md
+++ b/.github/workflows/docker-build-images.md
@@ -102,6 +102,7 @@ jobs:
 | **<code>oci-registry-username</code>** | Username used to log against the OCI registry. See <https://github.com/docker/login-action#usage>                                                                                                                                                                                   | <code>${{ github.repository_owner }}</code> | **false**    |
 | **<code>images</code>**                | Images to build parameters.                                                                                                                                                                                                                                                         |                                             | **true**     |
 |                                        | Example: <code>[{"name": "application","context": ".","dockerfile": "./docker/application/Dockerfile","build-args": { "APP_PATH": "./application/", "PROD_MODE": "true" },"target": "prod","platforms": ["linux/amd64",{"name": "darwin/amd64","runs-on": "macos-latest"}]}]</code> |                                             |              |
+| **<code>lfs</code>**                   | Enable Git LFS. See <https://github.com/actions/checkout?tab=readme-ov-file#usage>.                                                                                                                                                                                                 | <code>true</code>                           | **false**    |
 
 <!-- end inputs -->
 

--- a/.github/workflows/docker-build-images.yml
+++ b/.github/workflows/docker-build-images.yml
@@ -76,6 +76,13 @@ on: # yamllint disable-line rule:truthy
           ]
         type: string
         required: true
+      lfs:
+        description: |
+          Enable Git LFS.
+          See <https://github.com/actions/checkout?tab=readme-ov-file#usage>.
+        type: boolean
+        default: true
+        required: false
     secrets:
       oci-registry-password:
         description: |
@@ -282,6 +289,14 @@ jobs:
       # FIXME: This is a workaround for having workflow actions. See https://github.com/orgs/community/discussions/38659
       id-token: write
     steps:
+      - uses: hoverkraft-tech/ci-github-common/actions/checkout@0.17.0
+        with:
+          lfs: ${{ inputs.lfs }}
+
+      - if: inputs.lfs
+        shell: bash
+        run: git lfs pull
+
       # FIXME: This is a workaround for having workflow actions. See https://github.com/orgs/community/discussions/38659
       - id: oidc
         uses: ChristopherHX/oidc@v3
@@ -290,6 +305,8 @@ jobs:
           path: ./self-workflow
           repository: ${{ steps.oidc.outputs.job_workflow_repo_name_and_owner }}
           ref: ${{ steps.oidc.outputs.job_workflow_repo_ref }}
+          sparse-checkout: |
+            actions
       - run: |
           echo "self-workflow" >> .gitignore
           echo "self-workflow" >> .dockerignore
@@ -324,6 +341,8 @@ jobs:
           path: ./self-workflow
           repository: ${{ steps.oidc.outputs.job_workflow_repo_name_and_owner }}
           ref: ${{ steps.oidc.outputs.job_workflow_repo_ref }}
+          sparse-checkout: |
+            actions
 
   publish-manifests:
     name: Publish images manifests
@@ -379,6 +398,8 @@ jobs:
           path: ./self-workflow
           repository: ${{ steps.oidc.outputs.job_workflow_repo_name_and_owner }}
           ref: ${{ steps.oidc.outputs.job_workflow_repo_ref }}
+          sparse-checkout: |
+            actions
       - name: ignore self-worfklow changes
         run: |
           echo "self-workflow" >> .gitignore

--- a/.github/workflows/prune-pull-requests-images-tags.yml
+++ b/.github/workflows/prune-pull-requests-images-tags.yml
@@ -104,6 +104,8 @@ jobs:
           path: ./self-workflow
           repository: ${{ steps.oidc.outputs.job_workflow_repo_name_and_owner }}
           ref: ${{ steps.oidc.outputs.job_workflow_repo_ref }}
+          sparse-checkout: |
+            actions
 
       - id: build
         uses: ./self-workflow/actions/docker/prune-pull-requests-image-tags

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -188,13 +188,6 @@ runs:
         pull-request-cache: true
         cache-type: gha
 
-    - uses: hoverkraft-tech/ci-github-common/actions/checkout@0.17.0
-      with:
-        lfs: true
-
-    - shell: bash
-      run: git lfs pull
-
     - if: steps.get-docker-config.outputs.docker-exists != 'true'
       uses: docker/setup-docker-action@v4
 

--- a/actions/docker/get-image-metadata/action.yml
+++ b/actions/docker/get-image-metadata/action.yml
@@ -62,8 +62,6 @@ runs:
       if: inputs.tag == '' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'issue_comment')
       uses: hoverkraft-tech/ci-github-common/actions/get-issue-number@0.17.0
 
-    - uses: hoverkraft-tech/ci-github-common/actions/checkout@0.17.0
-
     - id: define-metadata-inputs
       uses: actions/github-script@v7.0.1
       with:


### PR DESCRIPTION
BREAKING CHANGE:

Actions "docker/get-image-metadata" and "docker/build-image" does not checkout the repository anymore.
It is done by the workflow "docker-build-images" before calling the actions.
This is a breaking change for workflows that use directly these actions and rely on the repository checkout.
