### PR TITLE
feat(prune-pull-requests-images-tags)!: do not prune cache images by default

### DIFF
--- a/.github/workflows/prune-pull-requests-images-tags.md
+++ b/.github/workflows/prune-pull-requests-images-tags.md
@@ -45,7 +45,8 @@ jobs:
       # Images to clean. Example: ["application-1","application-2"].
       images: ""
 
-      # Prune cache image tags  (like "application-1/cache"). Default: true
+      # Prune cache image tags (like "application-1/cache"). Useful when building image with "registry" cache backend.
+      # Default: true
       prune-cache-images: true
 
       # The regular expression to match pull request tags. Must have a capture group for the pull request number.
@@ -58,7 +59,7 @@ jobs:
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ------------ |
 | **<code>runs-on</code>**            | Json array of runner(s) to use. See [https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job](https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job) | <code>["ubuntu-latest"]</code>    | **false**    |
 | **<code>images</code>**             | Images to clean. Example: <code>["application-1","application-2"]</code>                                                                                                                       |                                   | **true**     |
-| **<code>prune-cache-images</code>** | Prune cache image tags (like "application-1/cache").                                                                                                                                           | <code>true</code>                 | **false**    |
+| **<code>prune-cache-images</code>** | Prune cache image tags (like "application-1/cache"). Useful when building image with "registry" cache backend.                                                                                 | <code>true</code>                 | **false**    |
 | **<code>prune-cache-images</code>** | The regular expression to match pull request tags. Must have a capture group for the pull request number.                                                                                      | <code>^pr-([0-9]+)(?:-\|$)</code> | **false**    |
 
 <!-- end inputs -->

--- a/.github/workflows/prune-pull-requests-images-tags.yml
+++ b/.github/workflows/prune-pull-requests-images-tags.yml
@@ -21,7 +21,7 @@ on:
         type: string
         required: true
       prune-cache-images:
-        description: 'Prune cache image tags  (like "application-1/cache"). Default: true'
+        description: 'Prune cache image tags (like "application-1/cache"). Useful when building image with "registry" cache backend.'
         type: boolean
         default: true
         required: false


### PR DESCRIPTION
As it is a modification of an input it is a breaking change, but it should not impact project that are using `docker-build-images` to build images, then using `prune-pull-requests-images-tags` to clean them.

> [!TIP]
>  Since [0.19.0](https://github.com/hoverkraft-tech/ci-github-container/releases/tag/0.19.0), `docker-build-images` is using `gha` backend cache, so no more cache image (`ghcr.io/my-org/my-repo/my-image/cache`) are created in the registry. It is reasonable to delete  the existing one are they are useless.