### PR TITLE
feat(prune-pull-requests-images-tags)!: do not prune cache images by default

### DIFF
--- a/.github/workflows/prune-pull-requests-images-tags.md
+++ b/.github/workflows/prune-pull-requests-images-tags.md
@@ -46,8 +46,8 @@ jobs:
       images: ""
 
       # Prune cache image tags (like "application-1/cache"). Useful when building image with "registry" cache backend.
-      # Default: true
-      prune-cache-images: true
+      # Default: false
+      prune-cache-images: false
 
       # The regular expression to match pull request tags. Must have a capture group for the pull request number.
       pull-request-tag-filter: "^pr-([0-9]+)(?:-|$)"

--- a/.github/workflows/prune-pull-requests-images-tags.yml
+++ b/.github/workflows/prune-pull-requests-images-tags.yml
@@ -23,7 +23,7 @@ on:
       prune-cache-images:
         description: 'Prune cache image tags (like "application-1/cache"). Useful when building image with "registry" cache backend.'
         type: boolean
-        default: true
+        default: false
         required: false
       pull-request-tag-filter:
         description: |


### PR DESCRIPTION
**prune-pull-requests-images-tags**: Cache images are no longer pruned by default, as it is a modification of an input it is a breaking change, but it should not impact project that are using `docker-build-images` to build images, then using `prune-pull-requests-images-tags` to clean them.

> [!TIP]
>  Since [0.19.0](https://github.com/hoverkraft-tech/ci-github-container/releases/tag/0.19.0), `docker-build-images` is using `gha` backend cache, so no more cache image (`ghcr.io/my-org/my-repo/my-image/cache`) are created in the registry. It is reasonable to delete  the existing one are they are useless.