### PR TITLE
feat(docker)!: add digest to images uri

### DIFF
--- a/.github/workflows/__shared-ci.yml
+++ b/.github/workflows/__shared-ci.yml
@@ -18,7 +18,7 @@ jobs:
   linter:
     uses: hoverkraft-tech/ci-github-common/.github/workflows/linter.yml@6857ef6d10f704e0998aa4955282f27d1b9be778 # 0.23.1
     with:
-      # FIXME: Remove this on next super-linter release
+      # FIXME: Remove useless linters on next super-linter release
       linter-env: |
         VALIDATE_JAVASCRIPT_PRETTIER=false
         VALIDATE_KUBERNETES_KUBECONFORM=false

--- a/.github/workflows/__test-action-docker-build-image.yml
+++ b/.github/workflows/__test-action-docker-build-image.yml
@@ -65,16 +65,12 @@ jobs:
               "hoverkraft-tech/ci-github-container/application-test",
               `"repository" output is not valid`
             );
-            assert.equal(
-              builtImage.digests.length,
-              1,
-              `"digests" output is not valid`
-            );
             assert.match(
-              builtImage.digests[0],
-              /^ghcr\.io\/hoverkraft-tech\/ci-github-container\/application-test@sha256:[a-f0-9]{64}$/,
-              `"digests" output is not valid`
+              builtImage.digest,
+              /^sha256:[a-f0-9]{64}$/,
+              `"digest" output is not valid`
             );
+            assert.equal(builtImage.image, `ghcr.io/hoverkraft-tech/ci-github-container/application-test@${builtImage.digest}`, `"image" output is not valid`);
 
             // Annotations
             assert.match(
@@ -124,45 +120,16 @@ jobs:
               assert.equal(builtImage.tags[1], prTag, `"tags" output is not valid`);
 
               assert.equal(
-                builtImage.images.length,
-                2,
-                `"images" output is not valid`
-              );
-              assert.equal(
-                builtImage.images[0],
-                `ghcr.io/hoverkraft-tech/ci-github-container/application-test:${prShaTag}`,
-                `"images" output is not valid`
-              );
-              assert.equal(
-                builtImage.images[1],
-                `ghcr.io/hoverkraft-tech/ci-github-container/application-test:${prTag}`,
-                `"images" output is not valid`
-              );
-              assert.equal(
                 builtImage.annotations["org.opencontainers.image.version"],
                 prTag,
                 `"annotations.org.opencontainers.image.version" output is not valid`
               );
-
             } else {
               const refTag = `${{ github.ref_name }}`;
 
               assert.equal(builtImage.tags.length, 2, `"tags" output is not valid`);
               assert.equal(builtImage.tags[0], refTag, `"tags" output is not valid`);
               assert.equal(builtImage.tags[1], "latest", `"tags" output is not valid`);
-
-              assert.equal(builtImage.images.length, 2, `"images" output is not valid`);
-              assert.equal(
-                builtImage.images[0],
-                `ghcr.io/hoverkraft-tech/ci-github-container/application-test:${refTag}`,
-                `"images" output is not valid`
-              );
-
-              assert.equal(
-                builtImage.images[1],
-                `ghcr.io/hoverkraft-tech/ci-github-container/application-test:latest`,
-                `"images" output is not valid`
-              );
 
               assert.equal(
                 builtImage.annotations["org.opencontainers.image.version"],
@@ -177,20 +144,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
-      - name: Assert - Check docker digests
+      - name: Assert - Check docker image
         run: |
-          DIGESTS=$(echo '${{ steps.build-image.outputs.built-image }}' | jq -r '.digests[]')
-          for DIGEST in $DIGESTS; do
-            if ! docker pull "$DIGEST"; then
-              echo "Failed to pull $DIGEST"
-              exit 1
-            fi
+          IMAGE=$(echo '${{ steps.build-image.outputs.built-image }}' | jq -r '.image')
+          if ! docker pull "$IMAGE"; then
+            echo "Failed to pull $IMAGE"
+            exit 1
+          fi
 
-            if ! docker manifest inspect "$DIGEST"; then
-              echo "Failed to inspect $DIGEST"
-              exit 1
-            fi
-          done
+          if ! docker manifest inspect "$IMAGE"; then
+            echo "Failed to inspect $IMAGE"
+            exit 1
+          fi
 
   tests-with-given-tag:
     name: Test for "docker/build-image" action with given tag
@@ -249,19 +214,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
 
-      - name: Assert - Check docker digests
+      - name: Assert - Check docker image
         run: |
-          DIGESTS=$(echo '${{ steps.build-image.outputs.built-image }}' | jq -r '.digests[]')
-          for DIGEST in $DIGESTS; do
-            if ! docker pull "$DIGEST"; then
-              echo "Failed to pull $DIGEST"
-              exit 1
-            fi
+          IMAGE=$(echo '${{ steps.build-image.outputs.built-image }}' | jq -r '.image')
+          if ! docker pull "$IMAGE"; then
+            echo "Failed to pull $IMAGE"
+            exit 1
+          fi
 
-            if ! docker manifest inspect "$DIGEST"; then
-              echo "Failed to inspect $DIGEST"
-              exit 1
-            fi
-          done
+          if ! docker manifest inspect "$IMAGE"; then
+            echo "Failed to inspect $IMAGE"
+            exit 1
+          fi
 
 # jscpd:ignore-end

--- a/.github/workflows/__test-action-docker-prune-pull-requests-image-tags.yml
+++ b/.github/workflows/__test-action-docker-prune-pull-requests-image-tags.yml
@@ -155,7 +155,7 @@ jobs:
 
             echo "$MANIFEST"
 
-            # Ensure all manifest digests didn't get deleted
+            # Ensure all manifests digest didn't get deleted
             for DIGEST in $(echo "$MANIFEST" | jq -r '.manifests[].digest'); do
               IMAGE_MANIFEST="ghcr.io/hoverkraft-tech/ci-github-container/${{ env.IMAGE }}@$DIGEST"
               docker pull "$IMAGE_MANIFEST"

--- a/.github/workflows/__test-workflow-docker-build-images.yml
+++ b/.github/workflows/__test-workflow-docker-build-images.yml
@@ -90,42 +90,36 @@ jobs:
             }
 
             const applicationMultiArchImage = builtImages["test-multi-arch"];
+
             assert.equal(applicationMultiArchImage.name, "test-multi-arch");
             assert.equal(applicationMultiArchImage.registry, "ghcr.io");
             assert.equal(applicationMultiArchImage.repository,"hoverkraft-tech/ci-github-container/test-multi-arch");
+            assert.match(applicationMultiArchImage.digest, /^sha256:[0-9a-f]{64}$/);
+
             assert(applicationMultiArchImage.tags.length);
             assert(applicationMultiArchImage.images.length);
             applicationMultiArchImage.images.forEach(
               image => assert.match(
                 image,
-                /^ghcr\.io\/hoverkraft-tech\/ci-github-container\/test-multi-arch:[\.a-z0-9-]+$/
+                /^ghcr\.io\/hoverkraft-tech\/ci-github-container\/test-multi-arch:[\.a-z0-9-]+@sha256:[0-9a-f]{64}$/
               )
             );
 
             const applicationMonoArchImage = builtImages["test-mono-arch"];
-            assert.equal(
-              applicationMonoArchImage.name,
-              "test-mono-arch"
-            );
-            assert.equal(
-              applicationMonoArchImage.registry,
-              "ghcr.io"
-            );
+
+            assert.equal(applicationMonoArchImage.name, "test-mono-arch");
+            assert.equal(applicationMonoArchImage.registry, "ghcr.io");
             assert.equal(
               applicationMonoArchImage.repository,
               "hoverkraft-tech/ci-github-container/test-mono-arch"
             );
-            assert.equal(
-              applicationMonoArchImage.tags.length,
-              1
-            );
-            assert.equal(
-              applicationMonoArchImage.images.length,
-              1
-            );
+            assert.match(applicationMonoArchImage.digest, /^sha256:[0-9a-f]{64}$/);
+
+            assert.equal(applicationMonoArchImage.tags.length, 1);
+            assert.equal(applicationMonoArchImage.images.length, 1);
             assert.equal(
               applicationMonoArchImage.images[0],
-              "ghcr.io/hoverkraft-tech/ci-github-container/test-mono-arch:0.1.0"
+              `ghcr.io/hoverkraft-tech/ci-github-container/test-mono-arch:0.1.0@${applicationMonoArchImage.digest}`
             );
 
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -367,8 +361,12 @@ jobs:
               expectedTag = `${{ github.ref_name }}`;
             }
 
+            const digest = `${{ fromJson(needs.act-build-args-secrets-and-registry-caching.outputs.built-images).test-build-args-secrets.digest }}`;
+            assert(digest.length, `"built-images" output does not contain digest for "test-build-args-secrets" image`);
+            assert.match(digest, /^sha256:[0-9a-f]{64}$/, `"built-images" output does not contain valid digest for "test-build-args-secrets" image`);
+
             const expectedImage = `ghcr.io/hoverkraft-tech/ci-github-container/test-build-args-secrets`;
-            const expectedImageTag = `${expectedImage}:${expectedTag}`;
+            const expectedImageTag = `${expectedImage}:${expectedTag}@${digest}`;
 
             const image = `${{ fromJson(needs.act-build-args-secrets-and-registry-caching.outputs.built-images).test-build-args-secrets.images[0] }}`;
 

--- a/.github/workflows/docker-build-images.md
+++ b/.github/workflows/docker-build-images.md
@@ -187,15 +187,15 @@ If a platform entry omits the <code>runs-on</code> field, the following default 
 
 ### Built image data
 
-| **Parameter**                | **Description**                    | **Example**                                                                                                                |
-| ---------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| **<code>name</code>**        | Image name                         | `application`                                                                                                              |
-| **<code>registry</code>**    | Registry where the image is stored | `ghcr.io`                                                                                                                  |
-| **<code>repository</code>**  | Repository name                    | `my-org/my-repo/application`                                                                                               |
-| **<code>tags</code>**        | List of tags                       | `["pr-63-5222075","pr-63"]`                                                                                                |
-| **<code>images</code>**      | List of images                     | `["ghcr.io/my-org/my-repo/application:pr-63-5222075","ghcr.io/my-org/my-repo/application:pr-63"]`                          |
-| **<code>digests</code>**     | List of digests                    | `["ghcr.io/my-org/my-repo/application@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"]`           |
-| **<code>annotations</code>** | List of annotations                | `{"org.opencontainers.image.created": "2021-09-30T14:00:00Z","org.opencontainers.image.description": "Application image"}` |
+| **Parameter**                | **Description**                    | **Example**                                                                                                                                                                                                                                       |
+| ---------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **<code>name</code>**        | Image name                         | `application`                                                                                                                                                                                                                                     |
+| **<code>registry</code>**    | Registry where the image is stored | `ghcr.io`                                                                                                                                                                                                                                         |
+| **<code>repository</code>**  | Repository name                    | `my-org/my-repo/application`                                                                                                                                                                                                                      |
+| **<code>tags</code>**        | List of tags                       | `["pr-63-5222075","pr-63"]`                                                                                                                                                                                                                       |
+| **<code>images</code>**      | List of images                     | `["ghcr.io/my-org/my-repo/application:pr-63-5222075@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d","ghcr.io/my-org/my-repo/application:pr-63@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"]` |
+| **<code>digest</code>**      |                                    | `sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d`                                                                                                                                                                         |
+| **<code>annotations</code>** | List of annotations                | `{"org.opencontainers.image.created": "2021-09-30T14:00:00Z","org.opencontainers.image.description": "Application image"}`                                                                                                                        |
 
 <!-- end outputs -->
 <!-- start [.github/ghadocs/examples/] -->

--- a/.github/workflows/docker-build-images.yml
+++ b/.github/workflows/docker-build-images.yml
@@ -19,12 +19,10 @@ on: # yamllint disable-line rule:truthy
               "repository": "my-org/my-repo/application",
               "tags": ["pr-63-5222075","pr-63"],
               "images": [
-                "ghcr.io/my-org/my-repo/application:pr-63-5222075",
-                "ghcr.io/my-org/my-repo/application:pr-63"
+                "ghcr.io/my-org/my-repo/application:pr-63-5222075@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
+                "ghcr.io/my-org/my-repo/application:pr-63@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"
               ],
-              "digests": [
-                "ghcr.io/my-org/my-repo/application@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"
-              ],
+              "digest": "sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
               "annotations": {
                 "org.opencontainers.image.created": "2021-09-30T14:00:00Z",
                 "org.opencontainers.image.description": "Application image"
@@ -441,7 +439,7 @@ jobs:
     needs: [prepare-variables, build-images]
     runs-on: ${{ fromJson(inputs.runs-on) }}
     outputs:
-      built-images: ${{ steps.built-images.outputs.built-images }}
+      built-images: ${{ steps.create-images-manifests.outputs.built-images }}
     steps:
       - id: get-matrix-outputs
         uses: hoverkraft-tech/ci-github-common/actions/get-matrix-outputs@6857ef6d10f704e0998aa4955282f27d1b9be778 # 0.23.1
@@ -463,15 +461,15 @@ jobs:
             // Group by image name
             const images = {};
             builtImages.forEach(builtImage => {
-              const { name, digests, ...image } = builtImage;
+              const { name, image, ...rest } = builtImage;
               if (!images[name]) {
                 images[name] = {
                   name,
-                  digests,
-                  ...image,
+                  images: [image],
+                  ...rest,
                 };
               } else {
-                images[name].digests = [...new Set([...images[name].digests, ...digests])];
+                images[name].images = [...new Set([...images[name].images, image])];
               }
             });
 
@@ -504,7 +502,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const builtImagesInput = `${{ steps.built-images.outputs.built-images }}`;
+            const builtImagesInput = `${{ steps.create-images-manifests.outputs.built-images }}`;
             let builtImages = null;
             try {
               builtImages = JSON.parse(builtImagesInput);

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -1,10 +1,14 @@
 ---
-name: "Build image"
-description: "Action to build an image with Docker for a specific platform"
-author: Hoverkraft
+name: "Docker - Build image"
+description: |
+  Action to build and push a "raw" image with Docker for a specific platform.
+  This action uses the Docker Buildx plugin to build the image.
+  It supports caching.
+  It returns the image digest uri, tags, and annotations, but does not handle it itself.
+author: hoverkraft
 branding:
   icon: package
-  color: gray-dark
+  color: blue
 
 outputs:
   built-image:
@@ -14,16 +18,11 @@ outputs:
         "name": "application",
         "registry": "ghcr.io",
         "repository": "my-org/my-repo/application",
+        "digest": "sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
+        "image": "ghcr.io/my-org/my-repo/application@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
         "tags": [
           "pr-63-5222075",
           "pr-63"
-        ],
-        "images": [
-          "ghcr.io/my-org/my-repo/application:pr-63-5222075",
-          "ghcr.io/my-org/my-repo/application:pr-63"
-        ],
-        "digests": [
-          "ghcr.io/my-org/my-repo/application@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"
         ],
         "annotations": {
           "org.opencontainers.image.created": "2021-09-30T14:00:00Z",
@@ -257,8 +256,7 @@ runs:
           }
 
           if (builtMetadata["containerimage.digest"] === undefined) {
-            core.setFailed('Given "metadata"."containerimage.digest" output is undefined.');
-            return;
+            return core.setFailed('Given "metadata"."containerimage.digest" output is undefined.');
           }
 
           const name = `${{ inputs.image }}`;
@@ -273,14 +271,25 @@ runs:
           .map(tag => tag.replace(/[^\/]+\/[^:]+:(.+)/,'$1').trim())
           .filter(tag => tag !== "");
 
-          const images = tags.map(tag => `${image}:${tag}`);
           const digests = builtMetadata["containerimage.digest"]
             .split(",")
             .map(digest => {
               const cleanedDigest = digest.trim();
-              return cleanedDigest !== "" ? `${image}@${cleanedDigest}` : null;
+              return cleanedDigest !== "" ? cleanedDigest : null;
             })
             .filter(digest => digest !== null);
+
+          const uniqueDigests = [...new Set(digests)];
+          if (uniqueDigests.length === 0) {
+            return core.setFailed('No valid digests found in "containerimage.digest" output.');
+          }
+
+          if( uniqueDigests.length > 1 ) {
+            return core.setFailed(`Multiple digests found: ${uniqueDigests.join(", ")}.`);
+          }
+
+          const digest = uniqueDigests[0];
+          const imageWithDigest = `${image}@${digest}`;
 
           const annotations = `${{ steps.metadata.outputs.annotations }}`
             .split("\n")
@@ -303,8 +312,8 @@ runs:
             annotations,
             registry,
             repository,
-            images,
-            digests,
+            image: imageWithDigest,
+            digest
           };
 
           core.setOutput("built-image", JSON.stringify(builtImage));

--- a/actions/docker/create-images-manifests/action.yml
+++ b/actions/docker/create-images-manifests/action.yml
@@ -1,10 +1,14 @@
 ---
-name: "Create images manifests"
-description: "Action to create built images manifests"
-author: Hoverkraft
+name: "Docker - Create images manifests"
+description: |
+  Action to create built images manifests.
+  It uses the Docker Buildx plugin to create manifests for the built images.
+  It requires the Docker Buildx plugin to be installed and configured.
+  It supports creating manifests for multiple images and platforms at once.
+author: hoverkraft
 branding:
   icon: package
-  color: gray-dark
+  color: blue
 
 inputs:
   oci-registry:
@@ -23,27 +27,54 @@ inputs:
     default: ${{ github.token }}
     required: true
   built-images:
-    description: 'Built images data. Example: {
-      "application": {
-      "name": "application",
-      "registry": "ghcr.io",
-      "repository": "my-org/my-repo/application",
-      "tags": ["pr-63-5222075","pr-63"],
-      "images": [
-      "ghcr.io/my-org/my-repo/application:pr-63-5222075",
-      "ghcr.io/my-org/my-repo/application:pr-63"
-      ],
-      "digests": [
-      "ghcr.io/my-org/my-repo/application@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
-      "ghcr.io/my-org/my-repo/application@sha256:0f5aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f402"
-      ],
-      "annotations": {
-      "org.opencontainers.image.created": "2021-09-30T14:00:00Z",
-      "org.opencontainers.image.description": "Application image"
+    description: |
+      Built images data.
+      Example:
+      ```json
+      {
+        "application": {
+          "name": "application",
+          "registry": "ghcr.io",
+          "repository": "my-org/my-repo/application",
+          "tags": ["pr-63-5222075","pr-63"],
+          "images": [
+            "ghcr.io/my-org/my-repo/application@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
+            "ghcr.io/my-org/my-repo/application@sha256:0f5aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f402",
+          ],
+          "annotations": {
+            "org.opencontainers.image.created": "2021-09-30T14:00:00Z",
+            "org.opencontainers.image.description": "Application image"
+          }
+        }
       }
-      }
-      }'
+      ```
     required: true
+
+outputs:
+  built-images:
+    description: |
+      Built images data.
+      Example:
+      ```json
+      {
+        "application": {
+          "name": "application",
+          "registry": "ghcr.io",
+          "repository": "my-org/my-repo/application",
+          "tags": ["pr-63-5222075","pr-63"],
+          "digest": "sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
+          "images": [
+            "ghcr.io/my-org/my-repo/application:pr-63-5222075@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
+            "ghcr.io/my-org/my-repo/application:pr-63@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"
+          ],
+          "annotations": {
+            "org.opencontainers.image.created": "2021-09-30T14:00:00Z",
+            "org.opencontainers.image.description": "Application image"
+          }
+        }
+      }
+      ```
+    value: ${{ steps.get-built-images-digest.outputs.built-images }}
 
 runs:
   using: "composite"
@@ -62,7 +93,8 @@ runs:
         username: ${{ inputs.oci-registry-username }}
         password: ${{ inputs.oci-registry-password }}
 
-    - name: Create SHA manifest and push
+    - id: create-images-manifests
+      name: Create images manifests and push
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
         script: |
@@ -78,25 +110,32 @@ runs:
           const commands = Object.keys(builtImages).map(imageName => {
             const builtImage = builtImages[imageName];
 
-            const tags = builtImage.images.map(image => {
+            const imagesWithTags = builtImage.tags.map(tag => {
+              return `${builtImage.registry}/${builtImage.repository}:${tag}`;
+            });
+
+            const tagsOption = imagesWithTags.map(image => {
               return `--tag ${image}`;
             }).join(" ");
 
-            const digests = builtImage.digests.join(" ");
+            const sources = builtImage.images.join(" ");
 
             const annotationLevels = ["index"];
-            const annotations = Object.keys(builtImage.annotations)
+            const annotationsOption = Object.keys(builtImage.annotations)
               .map(annotation => annotationLevels
                 .map(annotationLevel => `--annotation "${annotationLevel}:${annotation}=${builtImage.annotations[annotation]}"`)
               )
               .flat().join(" ");
 
-            const createManifestCommand = `docker buildx imagetools create ${annotations} ${tags} ${digests}`;
+            const createManifestCommand = `docker buildx imagetools create ${annotationsOption} ${tagsOption} ${sources}`;
 
             return new Promise(async (resolve, reject)  => {
               try {
                 await exec.exec(createManifestCommand);
                 core.debug(`Create manifest for "${builtImage.name}" ("${createManifestCommand}") executed`);
+
+                // Update builtImage with the images with tags
+                builtImage.images = imagesWithTags;
 
                 resolve();
               } catch(error){
@@ -108,3 +147,63 @@ runs:
           await Promise.all(commands);
 
           core.debug("Manifest created and pushed");
+
+          core.setOutput("built-images", JSON.stringify(builtImages));
+
+    - name: Get built images digest
+      id: get-built-images-digest
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const builtImagesOutputs = ${{ toJson(steps.create-images-manifests.outputs.built-images) }};
+          let builtImages = null;
+          try {
+            builtImages = JSON.parse(builtImagesOutputs);
+          } catch (error) {
+            throw new Error(`"built-images" output is not a valid JSON: ${error}`);
+          }
+
+          const getImageDigest = async function(image) {
+            // Check if the image already has a digest
+            if (image.match(/@/)) {
+              core.debug(`Image "${image}" already has a digest, skipping inspection.`);
+              return image;
+            }
+
+            const inspectImageCommand = `docker buildx imagetools inspect ${image}`;
+            core.debug(`Inspecting image "${image}" with command: "${inspectImageCommand}"`);
+
+            const { stdout } = await exec.getExecOutput(inspectImageCommand);
+
+            core.debug(`Inspect image "${image}" ("${inspectImageCommand}") executed: ${stdout}`);
+
+            if (!stdout) {
+              throw new Error(`Failed to retrieve manifest for image "${image}": "${inspectImageCommand}" returned empty output`);
+            }
+
+            // Retrieve digest from the manifest
+            const digestRegex = /Digest:\s+([a-z0-9]+:[a-z0-9]{64})/;
+            const digestMatch = stdout.match(digestRegex);
+            if (!digestMatch || digestMatch.length < 2) {
+              throw new Error(`Failed to retrieve digest for image "${image}": "${inspectImageCommand}" returned unexpected output: ${stdout}`);
+            }
+
+            const digest = digestMatch[1];
+            if (!digest) {
+              throw new Error(`Failed to retrieve digest for image "${image}": "${inspectImageCommand}" returned empty digest`);
+            }
+
+            core.debug(`Digest for image "${image}" is "${digest}"`);
+            return digest;
+          }
+
+          await Promise.all(Object.keys(builtImages).map(async (imageName) => {
+            const builtImage = builtImages[imageName];
+            const digest = await getImageDigest(builtImage.images[0]);
+
+            // Update built image with the digest
+            builtImage.digest = digest;
+            builtImage.images = builtImage.images.map(image => `${image}@${digest}`);
+          }));
+
+          core.setOutput("built-images", JSON.stringify(builtImages));

--- a/actions/docker/sign-images/action.yml
+++ b/actions/docker/sign-images/action.yml
@@ -16,15 +16,16 @@ inputs:
     description: |
       Images to sign.
       Can be a single image or a list of images separated by commas or newlines or spaces.
-      The images should be in the format `ghcr.io/my-org/my-repo/application:pr-63-5222075`.
+      The images should be in the format `registry/name:tag@digest`.
       It can also be a list of images in JSON format.
       Example:
       ```
         [
-          "ghcr.io/my-org/my-repo/application:pr-63-5222075",
-          "ghcr.io/my-org/my-repo/application:pr-63"
+          "ghcr.io/my-org/my-repo/application:pr-63-5222075@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
+          "ghcr.io/my-org/my-repo/application:pr-63@sha256:0f5aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f402"
         ]
       ```
+      If the image does not have a digest, it will retrieve the digest using `docker buildx imagetools inspect`.
     required: true
   github-token:
     description: |
@@ -43,59 +44,35 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const images = `${{ inputs.images }}`;
-          let imagesList = null;
+          const imagesInput = ${{ toJson(inputs.images) }};
+          let images = null;
           try {
             // Try to parse the input as JSON
-            imagesList = JSON.parse(images);
+            images = JSON.parse(imagesInput);
           } catch (error) {
             // If it fails, split the input by commas, newlines or spaces
-            imagesList = images.split(/[\s,]+/).filter(image => image.trim() !== "");
+            images = imagesInput.split(/[\s,]+/).filter(image => image.trim() !== "");
           }
 
-          if (!Array.isArray(imagesList) || imagesList.length === 0) {
-            throw new Error(`"images" input is not a valid JSON array or a non-empty string: ${images}`);
+          if (!Array.isArray(images) || images.length === 0) {
+            return core.setFailed(`"images" input is not a valid JSON array or a non-empty string: ${images}`);
           }
 
-          const getImageDigest = async function(image) {
-            // Check if the image already has a digest
-            if (image.match(/@/)) {
-              core.debug(`Image "${image}" already has a digest, skipping inspection.`);
-              return image;
+          // Ensure images are in the correct format
+          const imageRegex = /^[a-zA-Z0-9._-]+(?:\.[a-zA-Z0-9._-]+)*(?::[0-9]+)?\/(?:[a-z0-9._\/-]+):[a-zA-Z0-9._-]+@sha256:[a-f0-9]{64}$/;
+
+          for(const image of images) {
+            if (typeof image !== 'string'){
+              return core.setFailed(`Invalid image format: ${image}. Expected a string.`);
             }
 
-            const inspectImageCommand = `docker buildx imagetools inspect ${image}`;
-            core.debug(`Inspecting image "${image}" with command: "${inspectImageCommand}"`);
-
-            const { stdout } = await exec.getExecOutput(inspectImageCommand);
-
-            core.debug(`Inspect image "${image}" ("${inspectImageCommand}") executed: ${stdout}`);
-
-            if (!stdout) {
-              throw new Error(`Failed to retrieve manifest for image "${image}": "${inspectImageCommand}" returned empty output`);
+            if (!imageRegex.test(image)) {
+              return core.setFailed(`Invalid image format: ${image}. Expected format: registry/name:tag@digest`);
             }
-
-            // Retrieve digest from the manifest
-            const digestRegex = /Digest:\s+([a-z0-9]+:[a-z0-9]{64})/;
-            const digestMatch = stdout.match(digestRegex);
-            if (!digestMatch || digestMatch.length < 2) {
-              throw new Error(`Failed to retrieve digest for image "${image}": "${inspectImageCommand}" returned unexpected output: ${stdout}`);
-            }
-
-            const digest = digestMatch[1];
-            if (!digest) {
-              throw new Error(`Failed to retrieve digest for image "${image}": "${inspectImageCommand}" returned empty digest`);
-            }
-
-            core.debug(`Digest for image "${image}" is "${digest}"`);
-            return `${image}@${digest}`;
           }
-
-          // Wait for all images to be inspected and digests retrieved
-          const imagesWithDigests = await Promise.all(imagesList.map(image => getImageDigest(image)));
 
           // Create manifest for each image
-          const signImageCommand = `cosign sign --recursive --yes ${imagesWithDigests.map(image => `"${image}"`).join(" ")}`;
+          const signImageCommand = `cosign sign --recursive --yes ${images.join(" ")}`;
 
           core.debug(`Signing images with command: "${signImageCommand}"`);
           await exec.exec(signImageCommand);


### PR DESCRIPTION
To improve security, now `docker-build-images` workflow is returning the images uri with this format: `registry/name:tag@digest`. 

It returns also the "digest" of the image(s).

The `digests` (note the "s") does not exist anymore.

Example:

```json
{
  "application": {
    "name": "application",
    "registry": "ghcr.io",
    "repository": "my-org/my-repo/application",
    "tags": ["pr-63-5222075","pr-63"],
    "images": [
      "ghcr.io/my-org/my-repo/application:pr-63-5222075@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
      "ghcr.io/my-org/my-repo/application:pr-63@sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d"
    ],
    "digest": "sha256:d31aa93410434ac9dcfc9179cac2cb1fd4d7c27f11527addc40299c7c675f49d",
    "annotations": {
      "org.opencontainers.image.created": "2021-09-30T14:00:00Z",
      "org.opencontainers.image.description": "Application image"
    }
  }
}
```