### PR TITLE
fix(gha): workaround cache-to and cache-from scope

### DIFF
--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -207,6 +207,30 @@ runs:
         cache-type: ${{ inputs.cache-type }}
         extra-cache-to: "image-manifest=true,oci-mediatypes=true"
 
+    # FIXME: Remove this when https://github.com/int128/docker-build-cache-config-action/pull/1213 is merged
+    - id: transform-cache-gha
+      if: inputs.cache-type == 'gha'
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const cacheFrom = `${{ steps.cache.outputs.cache-from }}`;
+          const cacheTo = `${{ steps.cache.outputs.cache-to }}`;
+
+          core.info(`Original cache-from: ${cacheFrom}`);
+          core.info(`Original cache-to: ${cacheTo}`);
+
+          // Transform cache-from: replace ref= with scope=
+          const transformedCacheFrom = cacheFrom.replace(/ref=/g, 'scope=');
+
+          // Transform cache-to: replace ref= with scope=
+          const transformedCacheTo = cacheTo.replace(/ref=/g, 'scope=');
+
+          core.info(`Transformed cache-from: ${transformedCacheFrom}`);
+          core.info(`Transformed cache-to: ${transformedCacheTo}`);
+
+          core.setOutput('cache-from', transformedCacheFrom);
+          core.setOutput('cache-to', transformedCacheTo);
+
     - if: steps.get-docker-config.outputs.docker-exists != 'true'
       uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
 
@@ -239,8 +263,10 @@ runs:
         secrets: ${{ inputs.secrets }}
         secret-envs: ${{ inputs.secret-envs }}
         platforms: ${{ inputs.platform }}
-        cache-from: ${{ steps.cache.outputs.cache-from }}
-        cache-to: ${{ steps.cache.outputs.cache-to }}
+        # FIXME: Remove 'inputs.cache-type == 'gha' && steps.transform-cache-gha.outputs.cache-from ||' when https://github.com/int128/docker-build-cache-config-action/pull/1213 is merged
+        cache-from: ${{ inputs.cache-type == 'gha' && steps.transform-cache-gha.outputs.cache-from || steps.cache.outputs.cache-from }}
+        # FIXME: Remove 'inputs.cache-type == 'gha' && steps.transform-cache-gha.outputs.cache-to ||' when https://github.com/int128/docker-build-cache-config-action/pull/1213 is merged
+        cache-to: ${{ inputs.cache-type == 'gha' && steps.transform-cache-gha.outputs.cache-to || steps.cache.outputs.cache-to }}
         outputs: "type=image,push=true,push-by-digest=true,name-canonical=true,name=${{ steps.metadata.outputs.image }}"
         labels: ${{ steps.metadata.outputs.labels }}
         annotations: ${{ steps.metadata.outputs.annotations }}


### PR DESCRIPTION
This commit introduces a workaround for the GitHub Actions cache backend when using the docker `cache-from` and `cache-to` flags with BuildKit.

The current version of `int128/docker-build-cache-config-action` incorrectly uses `ref=` instead of `scope=` for the `gha` cache backend, which leads to shared caches across branches and builds, resulting in frequent invalidations and inefficient caching.

Until the upstream PR is merged and released:
https://github.com/int128/docker-build-cache-config-action/pull/1213

...this commit replace `ref=` by `scope=` to ensure proper cache isolation and reliable cache behavior in CI.

This workaround will be removed once the upstream fix is available in a stable release.

## For information
In our current CI setup, we rely on Docker layer caching to speed up multi-stage builds across different branches and commits. However, we noticed that intermediate layers were almost never reused, even when there were no code changes between builds.

This led to full rebuilds of our Docker images on every commit, with build times averaging 2–3 minutes.

After investigation, we identified the root cause:
the action [int128/docker-build-cache-config-action](https://github.com/int128/docker-build-cache-config-action) uses ref= instead of scope= when configuring cache-from and cache-to for the gha backend. According to [Docker’s documentation](https://docs.docker.com/build/cache/backends/gha/#scope), omitting scope= causes cache collisions across builds and branches, making caching unreliable.