### PR TITLE
feat(docker-build-image): support buildKit configuration

### DIFF
--- a/.github/workflows/docker-build-images.yml
+++ b/.github/workflows/docker-build-images.yml
@@ -104,6 +104,18 @@ on: # yamllint disable-line rule:truthy
         default: "gha"
         type: string
         required: false
+      buildkitd-config-inline:
+        description: |
+          Inline BuildKit daemon configuration.
+          See https://github.com/docker/setup-buildx-action#inputs.
+          Example for insecure registry:
+            ```ini
+            [registry."my-registry.local:5000"]
+              http = true
+              insecure = true
+            ```
+        type: string
+        required: false
       sign:
         description: |
           Sign built images.
@@ -427,6 +439,7 @@ jobs:
           secret-envs: ${{ steps.prepare-secret-envs.outputs.secret-envs }}
           secrets: ${{ secrets.build-secrets }}
           cache-type: ${{ inputs.cache-type }}
+          buildkitd-config-inline: ${{ inputs.buildkitd-config-inline }}
           multi-platform: ${{ matrix.image.multi-platform }}
 
       # FIXME: Set built images infos in file to be uploaded as artifacts, because github action does not handle job outputs for matrix

--- a/actions/docker/build-image/action.yml
+++ b/actions/docker/build-image/action.yml
@@ -101,6 +101,17 @@ inputs:
       See https://docs.docker.com/build/cache/backends.
     default: "gha"
     required: false
+  buildkitd-config-inline:
+    description: |
+      Inline BuildKit daemon configuration.
+      See https://github.com/docker/setup-buildx-action#inputs.
+      Example for insecure registry:
+        ```ini
+        [registry."my-registry.local:5000"]
+          http = true
+          insecure = true
+        ```
+    required: false
   multi-platform:
     description: |
       Whether this build participates in a multi-platform image publication.
@@ -153,6 +164,7 @@ runs:
         oci-registry: ${{ inputs.oci-registry }}
         oci-registry-username: ${{ inputs.oci-registry-username }}
         oci-registry-password: ${{ inputs.oci-registry-password }}
+        buildkitd-config-inline: ${{ inputs.buildkitd-config-inline }}
 
     - id: metadata
       uses: ./self-actions/docker/get-image-metadata

--- a/actions/docker/setup/action.yml
+++ b/actions/docker/setup/action.yml
@@ -25,6 +25,16 @@ inputs:
       Password or personal access token configuration used to log against OCI registries.
       Accepts either a single password/token string (default format) or a JSON object using the same keys as `oci-registry`.
     required: false
+  buildkitd-config-inline:
+    description: |
+      Inline BuildKit daemon configuration.
+      See https://github.com/docker/setup-buildx-action#inputs.
+      Example for insecure registry:
+        ```ini
+        [registry."my-registry.local:5000"]
+          http = true
+          insecure = true
+        ```
   built-images:
     description: |
       Optional built images payload used to resolve manifest publication registries.
@@ -387,6 +397,7 @@ runs:
         # FIXME: upgrade version when available (https://hub.docker.com/r/moby/buildkit)
         driver-opts: |
           image=moby/buildkit:v0.27.0
+        buildkitd-config-inline: ${{ inputs.buildkitd-config-inline }}
 
     - if: steps.resolve-oci-registries.outputs.has-registry-auth == 'true'
       uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0


### PR DESCRIPTION
This pull request adds support for passing an inline BuildKit daemon configuration (`buildkitd-config-inline`) through the Docker image build and setup GitHub Actions workflows. This enables advanced BuildKit configuration, such as specifying insecure registries, directly from workflow inputs.

Key changes:

**BuildKit Configuration Support:**

* Added a new optional `buildkitd-config-inline` input to `.github/workflows/docker-build-images.yml`, `actions/docker/build-image/action.yml`, and `actions/docker/setup/action.yml`, allowing users to provide inline BuildKit daemon configuration for custom build scenarios. [[1]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR107-R118) [[2]](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869R104-R114) [[3]](diffhunk://#diff-51bfe01abfe5c8cb29221e904305995cab366d429e9a880273be1fa08dcf6d87R28-R37)

**Workflow and Action Integration:**

* Updated the Docker build and setup workflows to pass the `buildkitd-config-inline` input through to the relevant build and setup steps, ensuring the configuration is properly propagated and used during the build process. [[1]](diffhunk://#diff-54a2aad43325eed5cae855e7a691fd0b09eb64ffdb2e2c4dd855672b69605b5cR442) [[2]](diffhunk://#diff-b1a31054574d361286a45d0269d77a0c0845e02d0ff84821308827c5e370a869R167) [[3]](diffhunk://#diff-51bfe01abfe5c8cb29221e904305995cab366d429e9a880273be1fa08dcf6d87R400)